### PR TITLE
ril: don't inherit LgeLteRIL

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/LS990RIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/LS990RIL.java
@@ -35,7 +35,7 @@ import com.android.internal.telephony.uicc.IccCardStatus;
  *
  * {@hide}
  */
-public class LS990RIL extends LgeLteRIL implements CommandsInterface {
+public class LS990RIL extends RIL implements CommandsInterface {
     static final String LOG_TAG = "LS990RIL";
 
     public LS990RIL(Context context, int preferredNetworkType,


### PR DESCRIPTION
This is causing com.android.phone to crash constantly

Change-Id: Idc1b6d145aaa5311e52db118f5bde7837dbb3017